### PR TITLE
Use API-reported maxima for filter life, if available

### DIFF
--- a/src/accessories/accessories.handler.js
+++ b/src/accessories/accessories.handler.js
@@ -448,7 +448,8 @@ class Handler {
 
       if (this.preFilterService) {
         const fltsts0change = this.obj.fltsts0 == 0;
-        const fltsts0life = (this.obj.fltsts0 / 360) * 100;
+        const fltsts0maxlife = (this.obj.flttotal0) ? this.obj.flttotal0 : 360
+        const fltsts0life = (this.obj.fltsts0 / fltsts0maxlife) * 100;
 
         this.preFilterService
           .updateCharacteristic(this.api.hap.Characteristic.FilterChangeIndication, fltsts0change)
@@ -457,7 +458,8 @@ class Handler {
 
       if (this.carbonFilterService) {
         const fltsts2change = this.obj.fltsts2 == 0;
-        const fltsts2life = (this.obj.fltsts2 / 4800) * 100;
+        const fltsts2maxlife = (this.obj.flttotal2) ? this.obj.flttotal2 : 4800        
+        const fltsts2life = (this.obj.fltsts2 / fltsts2maxlife) * 100;
 
         this.carbonFilterService
           .updateCharacteristic(this.api.hap.Characteristic.FilterChangeIndication, fltsts2change)
@@ -466,7 +468,8 @@ class Handler {
 
       if (this.hepaFilterService) {
         const fltsts1change = this.obj.fltsts1 == 0;
-        const fltsts1life = (this.obj.fltsts1 / 4800) * 100;
+        const fltsts1maxlife = (this.obj.flttotal1) ? this.obj.flttotal1 : 4800        
+        const fltsts1life = (this.obj.fltsts1 / fltsts1maxlife) * 100;
 
         this.hepaFilterService
           .updateCharacteristic(this.api.hap.Characteristic.FilterChangeIndication, fltsts1change)


### PR DESCRIPTION
At the moment the filter life characteristics use hardcoded maximum values (360 for the pre-filter, 4800 for the HEPA filter and carbon filter). On at least some models these are not the correct values, which generates the characteristic warnings mentioned in #7. 

The API output for my model of purifier (AC3033/73) actually reports the maximum values for the filter life in the `flttotal[0-2]` fields of the JSON. This PR uses those values to calculate the filter life characteristics if they're present. Because I don't know if they are available from every model, it falls back to the original hard-coded values if they aren't available.

As a side note, I suspect that `fltsts` and `flttotal` report values of 65535 if the filter in question doesn't exist on that particular model. (My purifier doesn't have a carbon filter, and that's what I see in `fltsts2` and `flttotal2`.)