### PR TITLE
Add required `active` property to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ sudo pip3 install -U git+https://github.com/Peter-J/aioairctrl
 | error            | Enables additional output (error) in the log.                | `true`                 | No       |
 | extendedError    | Enables additional output (detailed debug) in the log.       | `true`                 | No       |
 | **devices**      | Array of Philips air purifiers.                              |                        | Yes      |
+|- active          | Whether the device is active and should be used              |                        | Yes      |
 |- name            | Unique name of your device.                                  |                        | Yes      |
 |- **host**        | Host/IP address of your device.                              |                        | Yes      |
 |- port            | Port of your device.                                         | `5683`                 | No       |


### PR DESCRIPTION
This property is actually required and without it, the device is never loaded. Was initially confused by this when setting up the plugin and only ended up trying it because of the example config.